### PR TITLE
결제 파트 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.projectlombok:lombok:1.18.22'
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/mju/insuranceCompany/global/config/OuterSystemBean.java
+++ b/src/main/java/com/mju/insuranceCompany/global/config/OuterSystemBean.java
@@ -1,0 +1,15 @@
+package com.mju.insuranceCompany.global.config;
+
+import com.mju.outerSystem.ElectronicPaymentSystem;
+import com.mju.outerSystem.mockobject.MockElectronicPaymentSystem;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OuterSystemBean {
+
+    @Bean
+    public ElectronicPaymentSystem electronicPaymentSystem(){
+        return new MockElectronicPaymentSystem();
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
@@ -1,0 +1,21 @@
+package com.mju.insuranceCompany.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode{
+    NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다.")
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    public String getErrorName(){
+        return this.name();
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,17 @@
 package com.mju.insuranceCompany.global.exception;
 
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.util.NoSuchElementException;
+
 import static com.mju.insuranceCompany.global.exception.ErrorResponse.createErrorResponse;
+import static com.mju.insuranceCompany.global.exception.GlobalErrorCode.NO_SUCH_ELEMENT;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -17,4 +21,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ex.getHttpStatus())
                 .body(createErrorResponse(ex,request.getRequestURI()));
     }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException ex, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(createErrorResponse(NO_SUCH_ELEMENT,request.getRequestURI()));
+    }
+
 }

--- a/src/main/java/com/mju/insuranceCompany/global/utility/AuthenticationExtractor.java
+++ b/src/main/java/com/mju/insuranceCompany/global/utility/AuthenticationExtractor.java
@@ -1,0 +1,20 @@
+package com.mju.insuranceCompany.global.utility;
+
+import com.mju.insuranceCompany.service.user.domain.Users;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuthenticationExtractor {
+
+    public static int extractCustomerIdByAuthentication() {
+        return extractIdByAuthentication();
+    }
+
+    public static int extractEmployeeIdByAuthentication() {
+        return extractIdByAuthentication();
+    }
+
+    private static int extractIdByAuthentication(){
+        Users users = (Users) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return users.getRoleId();
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/contract/controller/dto/PaymentRegisterOnContractDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/controller/dto/PaymentRegisterOnContractDto.java
@@ -1,0 +1,13 @@
+package com.mju.insuranceCompany.service.contract.controller.dto;
+
+import lombok.Data;
+
+/*
+    NAME : 결제수단 등록하기
+    API : [PATCH] /customer/payment
+ */
+@Data
+public class PaymentRegisterOnContractDto {
+    private int contractId;
+    private int paymentId;
+}

--- a/src/main/java/com/mju/insuranceCompany/service/contract/domain/Contract.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/domain/Contract.java
@@ -1,6 +1,9 @@
 package com.mju.insuranceCompany.service.contract.domain;
 
 
+import com.mju.insuranceCompany.service.contract.exception.PaymentNotRegisteredException;
+import com.mju.insuranceCompany.service.customer.domain.payment.Payment;
+import com.mju.outerSystem.ElectronicPaymentSystem;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -28,7 +31,10 @@ public class Contract {
 	private String reasonOfUw;
 	@Enumerated(value = EnumType.STRING)
 	private ConditionOfUw conditionOfUw;
-	private int paymentId;
+
+	@OneToOne
+	@JoinColumn(name = "payment_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	private Payment payment;
 	private int insuranceId;
 	private int customerId;
 	private int employeeId;
@@ -47,5 +53,15 @@ public class Contract {
 		this.setConditionOfUw(conditionOfUw);
 
 		if (!conditionOfUw.getName().equals(ConditionOfUw.RE_AUDIT.getName())) this.setPublishStock(true);
+	}
+
+	public void registerPayment(Payment payment) {
+		this.payment = payment;
+	}
+
+	public void payPremium(ElectronicPaymentSystem electronicPaymentSystem){
+		if(payment == null)
+			throw new PaymentNotRegisteredException();
+		electronicPaymentSystem.pay(payment,premium);
 	}
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter @RequiredArgsConstructor
 public enum ContractErrorCode implements ErrorCode {
 
+    PAYMENT_NOT_REGISTERED(HttpStatus.NOT_FOUND,"결제수단이 등록되지 않았습니다.")
+
     ;
 
 

--- a/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter @RequiredArgsConstructor
 public enum ContractErrorCode implements ErrorCode {
 
-    PAYMENT_NOT_REGISTERED(HttpStatus.NOT_FOUND,"결제수단이 등록되지 않았습니다.")
+    PAYMENT_NOT_REGISTERED(HttpStatus.NOT_FOUND,"결제수단이 등록되지 않았습니다."),
+
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/service/contract/exception/PaymentNotRegisteredException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/exception/PaymentNotRegisteredException.java
@@ -1,0 +1,12 @@
+package com.mju.insuranceCompany.service.contract.exception;
+
+import com.mju.insuranceCompany.global.exception.ErrorCode;
+import com.mju.insuranceCompany.global.exception.MyException;
+
+import static com.mju.insuranceCompany.service.contract.exception.ContractErrorCode.PAYMENT_NOT_REGISTERED;
+
+public class PaymentNotRegisteredException extends MyException {
+    public PaymentNotRegisteredException() {
+        super(PAYMENT_NOT_REGISTERED);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/contract/repository/ContractRepository.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/repository/ContractRepository.java
@@ -4,10 +4,12 @@ import com.mju.insuranceCompany.service.contract.domain.CarContract;
 import com.mju.insuranceCompany.service.contract.domain.Contract;
 import com.mju.insuranceCompany.service.contract.domain.FireContract;
 import com.mju.insuranceCompany.service.contract.domain.HealthContract;
+import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
 import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfCustomerResponse;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,4 +29,11 @@ public interface ContractRepository extends JpaRepository<Contract, Integer> {
     Optional<FireContract> findFireContractById(int contractId);
 
     Optional<CarContract> findCarContractById(int contractId);
+
+    @Query("select new com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto(c.id, i.name, c.premium ) " +
+            "from Contract c inner join Insurance i on c.insuranceId = i.id " +
+            "where c.customerId = :customerId")
+    List<ContractReceiptDto> findAllContractReceipt(@Param("customerId") int customerId);
+
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/repository/ContractRepository.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/repository/ContractRepository.java
@@ -35,5 +35,7 @@ public interface ContractRepository extends JpaRepository<Contract, Integer> {
             "where c.customerId = :customerId")
     List<ContractReceiptDto> findAllContractReceipt(@Param("customerId") int customerId);
 
+    Optional<Contract> findContractByIdAndCustomerId(@Param("id") int id, @Param("customerId") int customerId);
+
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractPayService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractPayService.java
@@ -1,0 +1,23 @@
+package com.mju.insuranceCompany.service.contract.service;
+
+import com.mju.insuranceCompany.global.utility.AuthenticationExtractor;
+import com.mju.insuranceCompany.service.contract.domain.Contract;
+import com.mju.insuranceCompany.service.contract.repository.ContractRepository;
+import com.mju.outerSystem.ElectronicPaymentSystem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @Transactional @RequiredArgsConstructor
+public class ContractPayService {
+
+    private final ContractRepository contractRepository;
+    private final ElectronicPaymentSystem electronicPaymentSystem;
+
+    public void payForContractPremium(int contractId){
+        int customerId = AuthenticationExtractor.extractCustomerIdByAuthentication();
+        Contract contract = contractRepository.findContractByIdAndCustomerId(contractId, customerId).orElseThrow();
+        contract.payPremium(electronicPaymentSystem);
+
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
@@ -3,15 +3,19 @@ package com.mju.insuranceCompany.service.contract.service;
 import com.mju.insuranceCompany.service.contract.controller.dto.*;
 import com.mju.insuranceCompany.service.contract.domain.*;
 import com.mju.insuranceCompany.service.contract.repository.ContractRepository;
+import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
 import com.mju.insuranceCompany.service.customer.controller.dto.CustomerDto;
 import com.mju.insuranceCompany.service.customer.domain.Customer;
+import com.mju.insuranceCompany.service.customer.exception.ContractofCustomerNotFoundException;
 import com.mju.insuranceCompany.service.customer.repository.CustomerRepository;
 import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfCustomerResponse;
 import com.mju.insuranceCompany.service.insurance.controller.dto.InsuranceBasicInfoDto;
 import com.mju.insuranceCompany.service.insurance.domain.Insurance;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
 import com.mju.insuranceCompany.service.insurance.repository.InsuranceRepository;
+import com.mju.insuranceCompany.service.user.domain.Users;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +72,19 @@ public class ContractService {
     public void underwriting(int contractId, String reasonOfUw, ConditionOfUw conditionOfUw) {
         Contract contract = contractRepository.findById(contractId).orElseThrow();
         contract.underwriting(reasonOfUw, conditionOfUw);
+    }
+
+    public List<ContractReceiptDto> getAllContractReceipts(){
+        int customerId = extractCustomerIdByAuthentication();
+        List<ContractReceiptDto> receipts = contractRepository.findAllContractReceipt(customerId);
+        if(receipts.isEmpty())
+            throw new ContractofCustomerNotFoundException();
+        return receipts;
+    }
+
+    private int extractCustomerIdByAuthentication() {
+        Users users = (Users) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return users.getRoleId();
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
@@ -1,5 +1,6 @@
 package com.mju.insuranceCompany.service.contract.service;
 
+import com.mju.insuranceCompany.global.utility.AuthenticationExtractor;
 import com.mju.insuranceCompany.service.contract.controller.dto.*;
 import com.mju.insuranceCompany.service.contract.domain.*;
 import com.mju.insuranceCompany.service.contract.repository.ContractRepository;
@@ -75,16 +76,11 @@ public class ContractService {
     }
 
     public List<ContractReceiptDto> getAllContractReceipts(){
-        int customerId = extractCustomerIdByAuthentication();
+        int customerId = AuthenticationExtractor.extractCustomerIdByAuthentication();
         List<ContractReceiptDto> receipts = contractRepository.findAllContractReceipt(customerId);
         if(receipts.isEmpty())
             throw new ContractofCustomerNotFoundException();
         return receipts;
-    }
-
-    private int extractCustomerIdByAuthentication() {
-        Users users = (Users) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return users.getRoleId();
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/service/ContractService.java
@@ -83,4 +83,7 @@ public class ContractService {
         return receipts;
     }
 
+
+
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/service/PaymentRegisterService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/service/PaymentRegisterService.java
@@ -1,0 +1,36 @@
+package com.mju.insuranceCompany.service.contract.service;
+
+
+import com.mju.insuranceCompany.global.utility.AuthenticationExtractor;
+import com.mju.insuranceCompany.service.contract.controller.dto.PaymentRegisterOnContractDto;
+import com.mju.insuranceCompany.service.contract.domain.Contract;
+import com.mju.insuranceCompany.service.contract.repository.ContractRepository;
+import com.mju.insuranceCompany.service.customer.domain.Customer;
+import com.mju.insuranceCompany.service.customer.domain.payment.Payment;
+import com.mju.insuranceCompany.service.customer.exception.CustomerNotFoundException;
+import com.mju.insuranceCompany.service.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @RequiredArgsConstructor @Transactional
+public class PaymentRegisterService {
+
+    private final ContractRepository contractRepository;
+    private final CustomerRepository customerRepository;
+
+    public void registerPaymentOnContract(PaymentRegisterOnContractDto dto){
+        Customer customer = getCustomerByExtractedId();
+        Contract contract = contractRepository.findById(dto.getContractId()).orElseThrow();
+
+
+        Payment payment = customer.getPayment(dto.getPaymentId());
+        contract.registerPayment(payment);
+    }
+
+    private Customer getCustomerByExtractedId() {
+        int customerId = AuthenticationExtractor.extractCustomerIdByAuthentication();
+        return customerRepository.findById(customerId)
+                .orElseThrow(CustomerNotFoundException::new);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
@@ -1,4 +1,26 @@
 package com.mju.insuranceCompany.service.customer.controller;
 
+import com.mju.insuranceCompany.service.contract.service.ContractService;
+import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/customer")
+@RestController
 public class CustomerController {
+
+    private final ContractService contractService;
+
+    @GetMapping("/contract")
+    public ResponseEntity<List<ContractReceiptDto>> getAllContractReceipts(){
+        return ResponseEntity.ok(contractService.getAllContractReceipts());
+    }
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
@@ -2,11 +2,13 @@ package com.mju.insuranceCompany.service.customer.controller;
 
 import com.mju.insuranceCompany.service.contract.service.ContractService;
 import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
+import com.mju.insuranceCompany.service.customer.controller.dto.PaymentBasicInfoDto;
+import com.mju.insuranceCompany.service.customer.controller.dto.PaymentCreateDto;
+import com.mju.insuranceCompany.service.customer.service.CustomerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,10 +19,23 @@ import java.util.List;
 public class CustomerController {
 
     private final ContractService contractService;
+    private final CustomerService customerService;
 
     @GetMapping("/contract")
     public ResponseEntity<List<ContractReceiptDto>> getAllContractReceipts(){
         return ResponseEntity.ok(contractService.getAllContractReceipts());
     }
+
+    @GetMapping("/payment")
+    public ResponseEntity<List<PaymentBasicInfoDto>> getAllPaymentInfos(){
+        return ResponseEntity.ok(customerService.getAllPaymentInfos());
+    }
+
+    @PostMapping("/payment")
+    public ResponseEntity<Void> addNewPayment(@RequestBody PaymentCreateDto dto){
+        customerService.addNewPayment(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+//    @PatchMapping("/payment")
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/CustomerController.java
@@ -1,6 +1,9 @@
 package com.mju.insuranceCompany.service.customer.controller;
 
+import com.mju.insuranceCompany.service.contract.controller.dto.PaymentRegisterOnContractDto;
+import com.mju.insuranceCompany.service.contract.service.ContractPayService;
 import com.mju.insuranceCompany.service.contract.service.ContractService;
+import com.mju.insuranceCompany.service.contract.service.PaymentRegisterService;
 import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
 import com.mju.insuranceCompany.service.customer.controller.dto.PaymentBasicInfoDto;
 import com.mju.insuranceCompany.service.customer.controller.dto.PaymentCreateDto;
@@ -20,6 +23,8 @@ public class CustomerController {
 
     private final ContractService contractService;
     private final CustomerService customerService;
+    private final PaymentRegisterService paymentRegisterService;
+    private final ContractPayService contractPayService;
 
     @GetMapping("/contract")
     public ResponseEntity<List<ContractReceiptDto>> getAllContractReceipts(){
@@ -36,6 +41,15 @@ public class CustomerController {
         customerService.addNewPayment(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
-//    @PatchMapping("/payment")
+    @PatchMapping("/payment")
+    public ResponseEntity<Void> registerPaymentOnContract(@RequestBody PaymentRegisterOnContractDto dto){
+        paymentRegisterService.registerPaymentOnContract(dto);
+        return ResponseEntity.noContent().build();
+    }
+    @PostMapping("/pay/{contractId}")
+    public ResponseEntity<Void> payContractPremium(@PathVariable("contractId") int contractId){
+        contractPayService.payForContractPremium(contractId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/ContractReceiptDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/ContractReceiptDto.java
@@ -1,0 +1,19 @@
+package com.mju.insuranceCompany.service.customer.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/*
+    name : 계약 목록 조회
+    API : [GET] /customer/contract
+    설명 : 결제를 위한 정보를 받는 DTO
+          계약에 대한 결제 정보(이름, 값)이라서 Contract(계약) + Receipt(영수증)으로 명명
+ */
+@Data @AllArgsConstructor
+public class ContractReceiptDto {
+
+    private int contractId;
+    private String insuranceName;
+    private int premium;
+
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
@@ -16,8 +16,8 @@ public class PaymentBasicInfoDto {
     public static PaymentBasicInfoDto toDto(Payment payment) {
         PaymentBasicInfoDto dto = new PaymentBasicInfoDto();
         dto.setPaymentId(payment.getId());
-        dto.setPayType(payment.getPaytype());
-        if (payment.getPaytype().equals(PayType.CARD)) {
+        dto.setPayType(payment.getPayType());
+        if (payment.getPayType().equals(PayType.CARD)) {
             dto.setNo(((Card) payment).getCardNo());
         } else {
             dto.setNo(((Account) payment).getAccountNo());

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
@@ -1,0 +1,27 @@
+package com.mju.insuranceCompany.service.customer.controller.dto;
+
+import com.mju.insuranceCompany.service.customer.domain.payment.Account;
+import com.mju.insuranceCompany.service.customer.domain.payment.Card;
+import com.mju.insuranceCompany.service.customer.domain.payment.PayType;
+import com.mju.insuranceCompany.service.customer.domain.payment.Payment;
+import lombok.Data;
+
+@Data
+public class PaymentBasicInfoDto {
+
+    private int paymentId;
+    private PayType payType;
+    private String no;
+
+    public static PaymentBasicInfoDto toDto(Payment payment) {
+        PaymentBasicInfoDto dto = new PaymentBasicInfoDto();
+        dto.setPaymentId(payment.getId());
+        dto.setPayType(payment.getPaytype());
+        if (payment.getPaytype().equals(PayType.CARD)) {
+            dto.setNo(((Card) payment).getCardNo());
+        } else {
+            dto.setNo(((Account) payment).getAccountNo());
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentCreateDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentCreateDto.java
@@ -1,4 +1,8 @@
-package com.mju.insuranceCompany.service.customer.domain.payment;
+package com.mju.insuranceCompany.service.customer.controller.dto;
+
+import com.mju.insuranceCompany.service.customer.domain.payment.BankType;
+import com.mju.insuranceCompany.service.customer.domain.payment.CardType;
+import com.mju.insuranceCompany.service.customer.domain.payment.PayType;
 
 import java.time.LocalDate;
 
@@ -13,7 +17,7 @@ import java.time.LocalDate;
  * -----------------------------------------------------------
  * 2022-05-16                규현             최초 생성
  */
-public class PaymentDto {
+public class PaymentCreateDto {
 
     private PayType payType;
     private int customerId;
@@ -32,7 +36,7 @@ public class PaymentDto {
         return payType;
     }
 
-    public PaymentDto setPayType(PayType payType) {
+    public PaymentCreateDto setPayType(PayType payType) {
         this.payType = payType;
         return this;
     }
@@ -41,7 +45,7 @@ public class PaymentDto {
         return customerId;
     }
 
-    public PaymentDto setCustomerId(int customerId) {
+    public PaymentCreateDto setCustomerId(int customerId) {
         this.customerId = customerId;
         return this;
     }
@@ -50,7 +54,7 @@ public class PaymentDto {
         return cardNo;
     }
 
-    public PaymentDto setCardNo(String cardNo) {
+    public PaymentCreateDto setCardNo(String cardNo) {
         this.cardNo = cardNo;
         return this;
     }
@@ -59,7 +63,7 @@ public class PaymentDto {
         return cardType;
     }
 
-    public PaymentDto setCardType(CardType cardType) {
+    public PaymentCreateDto setCardType(CardType cardType) {
         this.cardType = cardType;
         return this;
     }
@@ -68,7 +72,7 @@ public class PaymentDto {
         return cvcNo;
     }
 
-    public PaymentDto setCvcNo(String cvcNo) {
+    public PaymentCreateDto setCvcNo(String cvcNo) {
         this.cvcNo = cvcNo;
         return this;
     }
@@ -77,7 +81,7 @@ public class PaymentDto {
         return expiryDate;
     }
 
-    public PaymentDto setExpiryDate(LocalDate expiryDate) {
+    public PaymentCreateDto setExpiryDate(LocalDate expiryDate) {
         this.expiryDate = expiryDate;
         return this;
     }
@@ -86,7 +90,7 @@ public class PaymentDto {
         return accountNo;
     }
 
-    public PaymentDto setAccountNo(String accountNo) {
+    public PaymentCreateDto setAccountNo(String accountNo) {
         this.accountNo = accountNo;
         return this;
     }
@@ -95,7 +99,7 @@ public class PaymentDto {
         return bankType;
     }
 
-    public PaymentDto setBankType(BankType bankType) {
+    public PaymentCreateDto setBankType(BankType bankType) {
         this.bankType = bankType;
         return this;
     }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
@@ -74,8 +74,8 @@ public class Customer {
 					.bankType(paymentCreateDto.getBankType())
 					.build();
 		}
-		payment.setPaytype(payType);
-		payment.setCustomerId(paymentCreateDto.getCustomerId());
+		payment.setPayType(payType);
+		payment.setCustomerId(this.id);
 		return payment;
 	}
 	// use-case: 결제 수단 추가

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
@@ -54,7 +54,6 @@ public class Customer {
 
 
 	public List<Payment> readPayments(){
-		//TODO DTO가 있다면.. 어떻게 화면에 그릴지랑 데이터를 고려해야 할 듯.
 		return this.paymentList;
 	}
 //

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Account.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Account.java
@@ -3,6 +3,7 @@ package com.mju.insuranceCompany.service.customer.domain.payment;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
@@ -15,7 +16,7 @@ import javax.persistence.Entity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Builder
+@Builder @Getter
 public class Account extends Payment {
 
 	private String accountNo;

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Account.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Account.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 /**
  * @author 규현
@@ -20,6 +22,8 @@ import javax.persistence.Entity;
 public class Account extends Payment {
 
 	private String accountNo;
+
+	@Enumerated(value = EnumType.STRING)
 	private BankType bankType;
 
 	@Override

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Card.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Card.java
@@ -3,6 +3,7 @@ package com.mju.insuranceCompany.service.customer.domain.payment;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Entity
 @Builder
+@Getter
 public class Card extends Payment {
 
 	private String cardNo;

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Card.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Card.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import java.time.LocalDate;
 
 /**
@@ -22,6 +24,7 @@ import java.time.LocalDate;
 public class Card extends Payment {
 
 	private String cardNo;
+	@Enumerated(value = EnumType.STRING)
 	private CardType cardType;
 	private String cvcNo;
 	private LocalDate expiryDate;

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/CardType.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/CardType.java
@@ -14,5 +14,5 @@ public enum CardType {
 	BC,
 	NH,
 	SAMSUNG,
-	HYNDAI
+	HYUNDAI
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Payment.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Payment.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 /**
  * @author 규현
@@ -25,6 +22,7 @@ public abstract class Payment {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	protected int id;
 	protected PayType paytype;
+	@JoinColumn(name = "customer_id")
 	protected int customerId;
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Payment.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/payment/Payment.java
@@ -15,13 +15,16 @@ import javax.persistence.*;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Inheritance(strategy = InheritanceType.JOINED)
 @Entity
 public abstract class Payment {
 
-	@Id
+	@Id @Column(name = "payment_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	protected int id;
-	protected PayType paytype;
+
+	@Enumerated(value = EnumType.STRING)
+	protected PayType payType;
 	@JoinColumn(name = "customer_id")
 	protected int customerId;
 

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/ContractofCustomerNotFoundException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/ContractofCustomerNotFoundException.java
@@ -1,0 +1,12 @@
+package com.mju.insuranceCompany.service.customer.exception;
+
+import com.mju.insuranceCompany.global.exception.ErrorCode;
+import com.mju.insuranceCompany.global.exception.MyException;
+
+import static com.mju.insuranceCompany.service.customer.exception.CustomerErrorCode.CONTRACT_OF_CUSTOMER_NOT_FOUND;
+
+public class ContractofCustomerNotFoundException extends MyException {
+    public ContractofCustomerNotFoundException() {
+        super(CONTRACT_OF_CUSTOMER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CustomerErrorCode implements ErrorCode {
 
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제수단 정보가 존재하지 않습니다."),
-    CONTRACT_OF_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객에게 가입된 계약 정보를 찾을 수 없습니다")
+    CONTRACT_OF_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객에게 가입된 계약 정보를 찾을 수 없습니다"),
+    CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객 정보가 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter @RequiredArgsConstructor
 public enum CustomerErrorCode implements ErrorCode {
 
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제수단 정보가 존재하지 않습니다.")
+
     ;
 
 

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter @RequiredArgsConstructor
 public enum CustomerErrorCode implements ErrorCode {
 
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제수단 정보가 존재하지 않습니다.")
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제수단 정보가 존재하지 않습니다."),
+    CONTRACT_OF_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객에게 가입된 계약 정보를 찾을 수 없습니다")
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerNotFoundException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerNotFoundException.java
@@ -1,0 +1,12 @@
+package com.mju.insuranceCompany.service.customer.exception;
+
+import com.mju.insuranceCompany.global.exception.ErrorCode;
+import com.mju.insuranceCompany.global.exception.MyException;
+
+import static com.mju.insuranceCompany.service.customer.exception.CustomerErrorCode.CUSTOMER_NOT_FOUND;
+
+public class CustomerNotFoundException extends MyException {
+    public CustomerNotFoundException() {
+        super(CUSTOMER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/PaymentNotFoundException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/PaymentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.mju.insuranceCompany.service.customer.exception;
+
+import com.mju.insuranceCompany.global.exception.ErrorCode;
+import com.mju.insuranceCompany.global.exception.MyException;
+
+import static com.mju.insuranceCompany.service.customer.exception.CustomerErrorCode.PAYMENT_NOT_FOUND;
+
+public class PaymentNotFoundException extends MyException {
+    public PaymentNotFoundException() {
+        super(PAYMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/customer/service/CustomerService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/service/CustomerService.java
@@ -1,4 +1,43 @@
 package com.mju.insuranceCompany.service.customer.service;
 
+import com.mju.insuranceCompany.global.utility.AuthenticationExtractor;
+import com.mju.insuranceCompany.service.customer.controller.dto.PaymentBasicInfoDto;
+import com.mju.insuranceCompany.service.customer.controller.dto.PaymentCreateDto;
+import com.mju.insuranceCompany.service.customer.domain.Customer;
+import com.mju.insuranceCompany.service.customer.exception.CustomerNotFoundException;
+import com.mju.insuranceCompany.service.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service @Transactional @RequiredArgsConstructor
 public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+
+    public List<PaymentBasicInfoDto> getAllPaymentInfos(){
+        Customer customer = getCustomerByExtractedId();
+        return customer.getPaymentList()
+                .stream()
+                .map(PaymentBasicInfoDto::toDto)
+                .toList();
+    }
+
+
+    public void addNewPayment(PaymentCreateDto paymentCreateDto){
+        Customer customer = getCustomerByExtractedId();
+        customer.addPayment(paymentCreateDto);
+    }
+
+    private Customer getCustomerByExtractedId() {
+        int customerId = AuthenticationExtractor.extractCustomerIdByAuthentication();
+        return customerRepository.findById(customerId)
+                .orElseThrow(CustomerNotFoundException::new);
+    }
+
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/service/CustomerService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/service/CustomerService.java
@@ -21,7 +21,7 @@ public class CustomerService {
 
     public List<PaymentBasicInfoDto> getAllPaymentInfos(){
         Customer customer = getCustomerByExtractedId();
-        return customer.getPaymentList()
+        return customer.readPayments()
                 .stream()
                 .map(PaymentBasicInfoDto::toDto)
                 .toList();

--- a/src/main/java/com/mju/outerSystem/ElectronicPaymentSystem.java
+++ b/src/main/java/com/mju/outerSystem/ElectronicPaymentSystem.java
@@ -1,16 +1,11 @@
 package com.mju.outerSystem;
 
 import com.mju.insuranceCompany.global.utility.ConsoleColors;
+import com.mju.insuranceCompany.service.customer.domain.payment.Payment;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public interface ElectronicPaymentSystem {
-
-
-    static void pay(String paymentInfo, int premium) {
-        LocalDateTime now = LocalDateTime.now();
-        String format = now.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분"));
-        System.out.println(ConsoleColors.YELLOW_BOLD+"[결제 완료] ("+format+") "+paymentInfo+premium + "원이 결제되었습니다."+ ConsoleColors.RESET);
-    }
+    void pay(Payment payment,int premium) ;
 }

--- a/src/main/java/com/mju/outerSystem/mockobject/MockElectronicPaymentSystem.java
+++ b/src/main/java/com/mju/outerSystem/mockobject/MockElectronicPaymentSystem.java
@@ -1,0 +1,13 @@
+package com.mju.outerSystem.mockobject;
+
+import com.mju.insuranceCompany.service.customer.domain.payment.Payment;
+import com.mju.outerSystem.ElectronicPaymentSystem;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MockElectronicPaymentSystem implements ElectronicPaymentSystem {
+    @Override
+    public void pay(Payment payment, int premium) {
+        log.info("{}원 결제 완료했습니다.",premium);
+    }
+}

--- a/src/test/java/com/mju/insuranceCompany/service/contract/repository/ContractRepositoryTest.java
+++ b/src/test/java/com/mju/insuranceCompany/service/contract/repository/ContractRepositoryTest.java
@@ -1,13 +1,18 @@
 package com.mju.insuranceCompany.service.contract.repository;
 
+import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
 import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfCustomerResponse;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -24,6 +29,21 @@ class ContractRepositoryTest {
 
             System.out.println(conditionOfUwOfCustomerResponse);
         }
+    }
+
+    @Transactional
+    @Test @DisplayName("고객ID를 통해 결제를 위한 정보를 읽어온다")
+    void readContractReceiptByCustomerId () throws Exception{
+        //given
+        int customerId = 7;
+        //when
+        List<ContractReceiptDto> receipt = repository.findAllContractReceipt(customerId);
+        //then
+
+        for (ContractReceiptDto dto : receipt) {
+            System.out.println(dto);
+        }
+        assertThat(receipt.size()).isSameAs(1);
 
 
     }

--- a/src/test/java/com/mju/insuranceCompany/service/contract/repository/ContractRepositoryTest.java
+++ b/src/test/java/com/mju/insuranceCompany/service/contract/repository/ContractRepositoryTest.java
@@ -1,9 +1,11 @@
 package com.mju.insuranceCompany.service.contract.repository;
 
+import com.mju.insuranceCompany.service.contract.domain.Contract;
 import com.mju.insuranceCompany.service.customer.controller.dto.ContractReceiptDto;
 import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfCustomerResponse;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,23 @@ class ContractRepositoryTest {
             System.out.println(dto);
         }
         assertThat(receipt.size()).isSameAs(1);
+
+
+    }
+    @Test
+    void readContractForPay () throws Exception{
+        //given
+        int contractId = 8;
+        int customerId = 8;
+        Contract contract = repository.findContractByIdAndCustomerId(contractId, customerId).orElseThrow();
+        //when
+
+        //then
+
+        SoftAssertions.assertSoftly(sa -> {
+            assertThat(contract.getCustomerId()).isSameAs(customerId);
+            assertThat(contract.getId()).isSameAs(contractId);
+        });
 
 
     }


### PR DESCRIPTION
### 추가 API
- 계약 목록 조회
- 결제하기
- 결제 수단 등록하기
- 결제 수단 추가하기
- 결제 수단 조회하기
**노션 API Customer 항목 참고**

---

### 도메인 클래스 변화

Contract.paymentId -> Contract.Payment
Payment.customerId => FK 설정
Customer.paymentList => Cascade 설정
Payment.id & payType 이름 조정(DB랑 맞춤)
Payment, Card, Account Enum ordinal -> string 으로 변경

---
### 서비스 클래스 추가
- PaymentRegisterService (Contract에 Payment 연결시키는 서비스)
 =>Contract, Customer 데이터에 같이 접근해서 연결해줘야 해서 따로 뺏음.
- ContractPayService (Contract에서 결제하는 서비스)
=> 외부 시스템 (전자결제시스템) 주입받아야 해서 따로 뺏음

