### PR TITLE
결제 수단 목록 조회 일부 수정

### DIFF
--- a/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/controller/dto/PaymentBasicInfoDto.java
@@ -11,6 +11,7 @@ public class PaymentBasicInfoDto {
 
     private int paymentId;
     private PayType payType;
+    private String companyName;
     private String no;
 
     public static PaymentBasicInfoDto toDto(Payment payment) {
@@ -19,8 +20,10 @@ public class PaymentBasicInfoDto {
         dto.setPayType(payment.getPayType());
         if (payment.getPayType().equals(PayType.CARD)) {
             dto.setNo(((Card) payment).getCardNo());
+            dto.setCompanyName(((Card) payment).getCardType().name());
         } else {
             dto.setNo(((Account) payment).getAccountNo());
+            dto.setCompanyName(((Account) payment).getBankType().name());
         }
         return dto;
     }

--- a/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/domain/Customer.java
@@ -5,6 +5,7 @@ import com.mju.insuranceCompany.service.accident.domain.complain.Complain;
 import com.mju.insuranceCompany.service.customer.controller.dto.CustomerDto;
 import com.mju.insuranceCompany.service.customer.controller.dto.PaymentCreateDto;
 import com.mju.insuranceCompany.service.customer.domain.payment.*;
+import com.mju.insuranceCompany.service.customer.exception.PaymentListEmptyException;
 import com.mju.insuranceCompany.service.customer.exception.PaymentNotFoundException;
 import com.mju.outerSystem.FinancialInstitute;
 import lombok.AllArgsConstructor;
@@ -54,6 +55,10 @@ public class Customer {
 
 
 	public List<Payment> readPayments(){
+		if(this.paymentList.isEmpty()){
+			throw new PaymentListEmptyException();
+		}
+
 		return this.paymentList;
 	}
 //

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
@@ -12,6 +12,8 @@ public enum CustomerErrorCode implements ErrorCode {
     CONTRACT_OF_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객에게 가입된 계약 정보를 찾을 수 없습니다"),
     CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객 정보가 존재하지 않습니다."),
 
+    PAYMENT_LIST_EMPTY(HttpStatus.NOT_FOUND, "등록된 결제수단이 존재하지 않습니다.")
+
     ;
 
 

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/PaymentListEmptyException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/PaymentListEmptyException.java
@@ -1,0 +1,12 @@
+package com.mju.insuranceCompany.service.customer.exception;
+
+import com.mju.insuranceCompany.global.exception.ErrorCode;
+import com.mju.insuranceCompany.global.exception.MyException;
+
+import static com.mju.insuranceCompany.service.customer.exception.CustomerErrorCode.PAYMENT_LIST_EMPTY;
+
+public class PaymentListEmptyException extends MyException {
+    public PaymentListEmptyException() {
+        super(PAYMENT_LIST_EMPTY);
+    }
+}


### PR DESCRIPTION
### 수정 사안
- Card, Account의 타입 포함해서 반환하도록 수정
- 조회 결과가 없을 경우 예외 반환하도록 수정

CardType, BankType은 카드, 계좌의 회사를 뜻해서 dto에 companyName 필드로 통합해서 사용했음.