### PR TITLE
예외 처리 기능 수정

### DIFF
--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode{
-    NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다.")
+    NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다."),
+    DB_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "현재 시스템 오류로 인해 원할한 작동이 불가능합니다.\n" +
+            "고객센터(1588-1588)로 연락 주시면 해결하겠습니다.")
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode{
     NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다."),
-    DB_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "현재 시스템 오류로 인해 원할한 작동이 불가능합니다.\n" +
+    DB_CONNECT_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "현재 시스템 오류로 인해 원할한 작동이 불가능합니다.\n" +
             "고객센터(1588-1588)로 연락 주시면 해결하겠습니다.")
 
     ;

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.net.ConnectException;
 import java.util.NoSuchElementException;
 
 import static com.mju.insuranceCompany.global.exception.ErrorResponse.createErrorResponse;
+import static com.mju.insuranceCompany.global.exception.GlobalErrorCode.DB_CONNECT_FAIL;
 import static com.mju.insuranceCompany.global.exception.GlobalErrorCode.NO_SUCH_ELEMENT;
 
 @RestControllerAdvice
@@ -26,6 +28,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(createErrorResponse(NO_SUCH_ELEMENT,request.getRequestURI()));
+
     }
+    //    DB 커넥션 에러 잡기
+    @ExceptionHandler(ConnectException.class)
+    public ResponseEntity<ErrorResponse> handleConnectException(ConnectException ex, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(createErrorResponse(DB_CONNECT_FAIL,request.getRequestURI()));
+    }
+
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/contract/exception/ContractErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter @RequiredArgsConstructor
 public enum ContractErrorCode implements ErrorCode {
 
-    PAYMENT_NOT_REGISTERED(HttpStatus.NOT_FOUND,"결제수단이 등록되지 않았습니다."),
+    PAYMENT_NOT_REGISTERED(HttpStatus.NOT_FOUND,"[알림] 해당 계약에 대해 결제 수단 정보가 없습니다. 설정해주세요."),
 
 
     ;

--- a/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/customer/exception/CustomerErrorCode.java
@@ -12,7 +12,7 @@ public enum CustomerErrorCode implements ErrorCode {
     CONTRACT_OF_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객에게 가입된 계약 정보를 찾을 수 없습니다"),
     CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "고객 정보가 존재하지 않습니다."),
 
-    PAYMENT_LIST_EMPTY(HttpStatus.NOT_FOUND, "등록된 결제수단이 존재하지 않습니다.")
+    PAYMENT_LIST_EMPTY(HttpStatus.NOT_FOUND, "등록된 결제수단이 존재하지 않습니다. \n결제 수단 추가 창을 열겠습니다.")
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/service/user/exception/UserErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/user/exception/UserErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다."),
-    USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 ID입니다.")
+    USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 ID입니다."),
+
+    LOGIN_FAILED(HttpStatus.NOT_FOUND, "아이디 혹은 비밀번호가 틀렸습니다.")
     ;
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/insurance?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/insurance?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=1234
 


### PR DESCRIPTION
### 추가
#### DB 연결 실패 예외 추가
발생 예외 클래스 :  java.net.ConntectException
핸들링 : GlobalExceptionHandler와 CustomerAuthenticationFailureHandler에서 처리

#### 로그인 예외 처리 추가
발생 예외 클래스 :  UserIdNotFoundException (ID가 틀렸을 때), BadCredentialException(비밀번호가 틀렸을 때)
핸들링 : CustomerAuthenticationFailureHandler에서 처리

### 에러 메세지 수정
프론트에서 예외 처리할 때, 백엔드에서 전달받은 ~~~ErrorCode.errorMessage를 그대로 사용하기 위해서 일부 내용 변경.
가급적이면 usecase 시나리오 상에서 있는 내용으로 바꾸려고 하고 있음.