### PR TITLE
판매인가파일 등록, 수정, 삭제 및 유저 아이디 중복체크 예외 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/main/resources/security.properties
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'org.projectlombok:lombok:1.18.22'
+
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
-    compileOnly 'org.projectlombok:lombok'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-aws
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
+
+    implementation 'org.projectlombok:lombok:1.18.22'
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/mju/insuranceCompany/InsuranceCompanyApplication.java
+++ b/src/main/java/com/mju/insuranceCompany/InsuranceCompanyApplication.java
@@ -6,6 +6,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class InsuranceCompanyApplication {
 
+    /*
+    여기서의 핵심은 com.amazonaws.sdk.disableEc2Metadata 속성을 true로 설정해주는것입니다.
+    만약 해당 설정을 하지 않을 경우 서비스가 실행되는 시점에 약간의 지연이 발생하고 다음과 같은 예외 메세지가 발생합니다.
+     */
+    static {
+        System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(InsuranceCompanyApplication.class, args);
     }

--- a/src/main/java/com/mju/insuranceCompany/global/config/BeanConfig.java
+++ b/src/main/java/com/mju/insuranceCompany/global/config/BeanConfig.java
@@ -1,5 +1,10 @@
 package com.mju.insuranceCompany.global.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -10,5 +15,26 @@ public class BeanConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // AWS S3 Bean Config
+    @Value("${cloud.aws.credentials.access-key}")
+    private String s3AccessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String s3SecretKey;
+    @Value("${cloud.aws.region.static}")
+    private String s3Region;
+
+    @Bean
+    public BasicAWSCredentials basicAWSCredentials() {
+        return new BasicAWSCredentials(s3AccessKey, s3SecretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(BasicAWSCredentials basicAWSCredentials) {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(s3Region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
     }
 }

--- a/src/main/java/com/mju/insuranceCompany/global/config/WebConfig.java
+++ b/src/main/java/com/mju/insuranceCompany/global/config/WebConfig.java
@@ -1,10 +1,12 @@
 package com.mju.insuranceCompany.global.config;
 
+import com.mju.insuranceCompany.global.config.converter.SalesAuthFileTypeConverter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-//@Configuration
+@Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     @Override
@@ -14,4 +16,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET","POST","PUT","PATCH","DELETE");
     }
 
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new SalesAuthFileTypeConverter());
+    }
 }

--- a/src/main/java/com/mju/insuranceCompany/global/config/converter/SalesAuthFileTypeConverter.java
+++ b/src/main/java/com/mju/insuranceCompany/global/config/converter/SalesAuthFileTypeConverter.java
@@ -1,0 +1,11 @@
+package com.mju.insuranceCompany.global.config.converter;
+
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthFileType;
+import org.springframework.core.convert.converter.Converter;
+
+public class SalesAuthFileTypeConverter implements Converter<String, SalesAuthFileType> {
+    @Override
+    public SalesAuthFileType convert(String source) {
+        return SalesAuthFileType.ofType(source);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/global/exception/ErrorResponse.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/ErrorResponse.java
@@ -19,8 +19,13 @@ public class ErrorResponse {
     private String path;
 
     public static ErrorResponse createErrorResponse(ErrorCode errorCode, String path) {
-        return new ErrorResponse(LocalDateTime.now().toString(),errorCode.getHttpStatus()
-        , errorCode.getErrorName(), errorCode.getErrorMessage(),path);
+        return new ErrorResponse(
+                LocalDateTime.now().toString(),
+                errorCode.getHttpStatus(),
+                errorCode.getErrorName(),
+                errorCode.getErrorMessage(),
+                path
+        );
     }
 
     @Override

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode{
-    NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다.")
-
+    NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "정보를 조회할 수 없습니다."),
     ;
 
 

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.util.NoSuchElementException;
 
 import static com.mju.insuranceCompany.global.exception.ErrorResponse.createErrorResponse;
@@ -25,7 +24,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(createErrorResponse(NO_SUCH_ELEMENT,request.getRequestURI()));
+                .body(createErrorResponse(NO_SUCH_ELEMENT, request.getRequestURI()));
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mju/insuranceCompany/global/exception/GlobalExceptionHandler.java
@@ -30,7 +30,10 @@ public class GlobalExceptionHandler {
                 .body(createErrorResponse(NO_SUCH_ELEMENT,request.getRequestURI()));
 
     }
-    //    DB 커넥션 에러 잡기
+
+    /**
+     * DB 커넥션 에러 잡기
+     */
     @ExceptionHandler(ConnectException.class)
     public ResponseEntity<ErrorResponse> handleConnectException(ConnectException ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/mju/insuranceCompany/global/utility/S3Client.java
+++ b/src/main/java/com/mju/insuranceCompany/global/utility/S3Client.java
@@ -1,0 +1,68 @@
+package com.mju.insuranceCompany.global.utility;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Client {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    public String uploadFile(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()) return null;
+        try {
+            File file = convertMultipartFileToFile(multipartFile).orElseThrow();
+            return upload(file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+        File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+        if (file.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(file)){
+                fos.write(multipartFile.getBytes());
+            }
+            return Optional.of(file);
+        }
+        return Optional.empty();
+    }
+
+    private String upload(File file) {
+        String fileName = "upload/" + UUID.randomUUID();
+        return putS3(file, fileName);
+    }
+
+    private String putS3(File file, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, file)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        removeFile(file); // Delete local file instance
+
+        return getS3(bucket, fileName);
+    }
+
+    private String getS3(String bucket, String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeFile(File file) {
+        file.delete();
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
@@ -10,7 +10,7 @@ import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfC
 import com.mju.insuranceCompany.service.employee.controller.dto.UnderwritingRequest;
 import com.mju.insuranceCompany.service.insurance.controller.dto.*;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
-import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationFile;
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthFileType;
 import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationState;
 import com.mju.insuranceCompany.service.insurance.service.InsuranceService;
 import lombok.RequiredArgsConstructor;
@@ -161,95 +161,51 @@ public class EmployeeController {
     }
 
     /**
-     * 보험상품신고서 등록
-     * @param insId 보험 ID
-     * @param multipartFile 보험상품신고서 파일
-     * @return UploadAuthFIleResultDto(isExistAllFile)
+     * 판매인가파일 등록
+     * @param type 판매인가파일 타입
+     * @param insId 보험 id
+     * @param multipartFile 등록할 판매인가파일
+     * @return UploadAuthFileResultDto(isExistAllFile)
      */
-    @PostMapping("/dev/auth-file/save/prod/{insId}")
-    public ResponseEntity<UploadAuthFileResultDto> uploadProdDeclarationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.PROD));
+    @PostMapping("/dev/auth-file/{type}/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> uploadSalesAuthorizationFile(
+            @PathVariable SalesAuthFileType type, @PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, type));
     }
 
     /**
-     * 보험요율산출기관 검증확인서 등록
-     * @param insId 보험 ID
-     * @param multipartFile 보험요율산출기관 검증확인서 파일
-     * @return UploadAuthFIleResultDto(isExistAllFile)
+     * 판매인가파일 수정
+     * @param type 판매인가파일 타입
+     * @param insId 보험 id
+     * @param multipartFile 수정할 판매인가파일
+     * @return UploadAuthFileResultDto(isExistAllFile)
      */
-    @PostMapping("/dev/auth-file/save/iso/{insId}")
-    public ResponseEntity<UploadAuthFileResultDto> uploadIsoVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.ISO));
+    @PatchMapping("/dev/auth-file/{type}/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> updateSalesAuthorizationFile(
+            @PathVariable SalesAuthFileType type, @PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.updateAuthFile(insId, multipartFile, type));
     }
 
     /**
-     * 선임계리사 검증기초서류 등록
-     * @param insId 보험 ID
-     * @param multipartFile 선임계리사 검증기초서류 파일
-     * @return UploadAuthFIleResultDto(isExistAllFile)
+     * 판매인가파일 삭제
+     * @param type 판매인가파일 타입
+     * @param insId 보험 id
+     * @return no content
      */
-    @PostMapping("/dev/auth-file/save/sractuary/{insId}")
-    public ResponseEntity<UploadAuthFileResultDto> uploadSrActuaryVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY));
-        }
-
-    /**
-     * 금융감독원 인가허가파일 등록
-     * @param insId 보험 ID
-     * @param multipartFile 금융감독원 인가허가파일 파일
-     * @return UploadAuthFIleResultDto(isExistAllFile)
-     */
-    @PostMapping("/dev/auth-file/save/fssofficial/{insId}")
-    public ResponseEntity<UploadAuthFileResultDto> uploadFssOfficialDocFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL));
+    @DeleteMapping("/dev/auth-file/{type}/{insId}")
+    public ResponseEntity deleteSalesAuthorizationFile(@PathVariable SalesAuthFileType type, @PathVariable int insId) {
+        insuranceService.deleteAuthFile(insId, type);
+        return ResponseEntity.noContent().build();
     }
 
-    //보험상품신고서 수정
-    @PatchMapping("/dev/auth-file/update/prod/{insuranceId}")
-    public ResponseEntity<UploadAuthFileResultDto> updateProdDeclarationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.PROD));
-    }
-    //보험요율산출기관 검증확인서 수정
-    @PatchMapping("/dev/auth-file/update/iso/{insuranceId}")
-    public ResponseEntity<UploadAuthFileResultDto> updateIsoVerificationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.ISO));
-    }
-    //선임계리사 검증기초서류 수정
-    @PatchMapping("/dev/auth-file/update/sractuary/{insuranceId}")
-    public ResponseEntity<UploadAuthFileResultDto> updateSrActuaryVerificationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY));
-    }
-    //금융감독원 인가허가파일 수정
-    @PatchMapping("/dev/auth-file/update/fssofficial/{insuranceId}")
-    public ResponseEntity<UploadAuthFileResultDto> updateSFssOfficialDocFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL));
-    }
-
-    //보험상품신고서 삭제
-    @DeleteMapping("/dev/auth-file/delete/prod/{insuranceId}")
-    public ResponseEntity deleteProdDeclarationFile(@PathVariable int insuranceId) {
-        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.PROD);
-        return ResponseEntity.ok().build();
-    }
-    //보험요율산출기관 검증확인서 삭제
-    @DeleteMapping("/dev/auth-file/delete/iso/{insuranceId}")
-    public ResponseEntity deleteIsoVerificationFile(@PathVariable int insuranceId) {
-        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.ISO);
-        return ResponseEntity.ok().build();
-    }
-    //선임계리사 검증기초서류 삭제
-    @DeleteMapping("/dev/auth-file/delete/sractuary/{insuranceId}")
-    public ResponseEntity deleteSrActuaryVerificationFile(@PathVariable int insuranceId) {
-        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY);
-        return ResponseEntity.ok().build();
-    }
-    //금융감독원 인가허가파일 삭제
-    @DeleteMapping("/dev/auth-file/delete/fssofficial/{insuranceId}")
-    public ResponseEntity deleteFssOfficialFile(@PathVariable int insuranceId) {
-        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL);
-        return ResponseEntity.ok().build();
-    }
     //판매인가상태 변경
+
+    /**
+     * 판매인가상태 변경
+     * @param insuranceId 보험 id
+     * @param salesAuthorizationState 변경할 판매인가상태
+     * @return no content
+     */
     @PatchMapping("/dev/update-auth-state/{insuranceId}")
     public ResponseEntity updateSalesAuthorizationState(@PathVariable int insuranceId, @RequestBody SalesAuthorizationState salesAuthorizationState) {
         insuranceService.updateSalesAuthorizationState(insuranceId, salesAuthorizationState);

--- a/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
@@ -10,6 +10,8 @@ import com.mju.insuranceCompany.service.employee.controller.dto.ConditionOfUwOfC
 import com.mju.insuranceCompany.service.employee.controller.dto.UnderwritingRequest;
 import com.mju.insuranceCompany.service.insurance.controller.dto.*;
 import com.mju.insuranceCompany.service.insurance.domain.InsuranceType;
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationFile;
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationState;
 import com.mju.insuranceCompany.service.insurance.service.InsuranceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -166,7 +168,7 @@ public class EmployeeController {
      */
     @PostMapping("/dev/auth-file/save/prod/{insId}")
     public ResponseEntity<UploadAuthFileResultDto> uploadProdDeclarationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadProdDeclarationFile(insId, multipartFile));
+        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.PROD));
     }
 
     /**
@@ -177,7 +179,7 @@ public class EmployeeController {
      */
     @PostMapping("/dev/auth-file/save/iso/{insId}")
     public ResponseEntity<UploadAuthFileResultDto> uploadIsoVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadIsoVerificationFile(insId, multipartFile));
+        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.ISO));
     }
 
     /**
@@ -188,7 +190,7 @@ public class EmployeeController {
      */
     @PostMapping("/dev/auth-file/save/sractuary/{insId}")
     public ResponseEntity<UploadAuthFileResultDto> uploadSrActuaryVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-            return ResponseEntity.ok(insuranceService.uploadSrActuaryVerificationFile(insId, multipartFile));
+        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY));
         }
 
     /**
@@ -199,7 +201,59 @@ public class EmployeeController {
      */
     @PostMapping("/dev/auth-file/save/fssofficial/{insId}")
     public ResponseEntity<UploadAuthFileResultDto> uploadFssOfficialDocFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
-        return ResponseEntity.ok(insuranceService.uploadFssOfficialDocFile(insId, multipartFile));
+        return ResponseEntity.ok(insuranceService.uploadAuthFile(insId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL));
+    }
+
+    //보험상품신고서 수정
+    @PatchMapping("/dev/auth-file/update/prod/{insuranceId}")
+    public ResponseEntity<UploadAuthFileResultDto> updateProdDeclarationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.PROD));
+    }
+    //보험요율산출기관 검증확인서 수정
+    @PatchMapping("/dev/auth-file/update/iso/{insuranceId}")
+    public ResponseEntity<UploadAuthFileResultDto> updateIsoVerificationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.ISO));
+    }
+    //선임계리사 검증기초서류 수정
+    @PatchMapping("/dev/auth-file/update/sractuary/{insuranceId}")
+    public ResponseEntity<UploadAuthFileResultDto> updateSrActuaryVerificationFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY));
+    }
+    //금융감독원 인가허가파일 수정
+    @PatchMapping("/dev/auth-file/update/fssofficial/{insuranceId}")
+    public ResponseEntity<UploadAuthFileResultDto> updateSFssOfficialDocFile(@PathVariable int insuranceId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.updateAuthFile(insuranceId, multipartFile, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL));
+    }
+
+    //보험상품신고서 삭제
+    @DeleteMapping("/dev/auth-file/delete/prod/{insuranceId}")
+    public ResponseEntity deleteProdDeclarationFile(@PathVariable int insuranceId) {
+        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.PROD);
+        return ResponseEntity.ok().build();
+    }
+    //보험요율산출기관 검증확인서 삭제
+    @DeleteMapping("/dev/auth-file/delete/iso/{insuranceId}")
+    public ResponseEntity deleteIsoVerificationFile(@PathVariable int insuranceId) {
+        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.ISO);
+        return ResponseEntity.ok().build();
+    }
+    //선임계리사 검증기초서류 삭제
+    @DeleteMapping("/dev/auth-file/delete/sractuary/{insuranceId}")
+    public ResponseEntity deleteSrActuaryVerificationFile(@PathVariable int insuranceId) {
+        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.SR_ACTUARY);
+        return ResponseEntity.ok().build();
+    }
+    //금융감독원 인가허가파일 삭제
+    @DeleteMapping("/dev/auth-file/delete/fssofficial/{insuranceId}")
+    public ResponseEntity deleteFssOfficialFile(@PathVariable int insuranceId) {
+        insuranceService.deleteAuthFile(insuranceId, SalesAuthorizationFile.SalesAuthFileType.FSS_OFFICIAL);
+        return ResponseEntity.ok().build();
+    }
+    //판매인가상태 변경
+    @PatchMapping("/dev/update-auth-state/{insuranceId}")
+    public ResponseEntity updateSalesAuthorizationState(@PathVariable int insuranceId, @RequestBody SalesAuthorizationState salesAuthorizationState) {
+        insuranceService.updateSalesAuthorizationState(insuranceId, salesAuthorizationState);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/employee/controller/EmployeeController.java
@@ -14,6 +14,7 @@ import com.mju.insuranceCompany.service.insurance.service.InsuranceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -145,6 +146,60 @@ public class EmployeeController {
     public ResponseEntity saveFireInsurance(@RequestBody SaveFireInsuranceDto saveFireInsuranceDto) {
         insuranceService.saveFireInsurance(saveFireInsuranceDto);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 인가파일 등록할 보험 정보 조회
+     * @param insId 보험 ID
+     * @return InsuranceForUploadAuthFileDto
+     */
+    @GetMapping("/dev/auth-file/{insId}")
+    public ResponseEntity<InsuranceForUploadAuthFileDto> getInsuranceInfoForUploadAuthFile(@PathVariable int insId) {
+        return ResponseEntity.ok(insuranceService.getInsuranceInfoForUploadAuthFile(insId));
+    }
+
+    /**
+     * 보험상품신고서 등록
+     * @param insId 보험 ID
+     * @param multipartFile 보험상품신고서 파일
+     * @return UploadAuthFIleResultDto(isExistAllFile)
+     */
+    @PostMapping("/dev/auth-file/save/prod/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> uploadProdDeclarationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.uploadProdDeclarationFile(insId, multipartFile));
+    }
+
+    /**
+     * 보험요율산출기관 검증확인서 등록
+     * @param insId 보험 ID
+     * @param multipartFile 보험요율산출기관 검증확인서 파일
+     * @return UploadAuthFIleResultDto(isExistAllFile)
+     */
+    @PostMapping("/dev/auth-file/save/iso/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> uploadIsoVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.uploadIsoVerificationFile(insId, multipartFile));
+    }
+
+    /**
+     * 선임계리사 검증기초서류 등록
+     * @param insId 보험 ID
+     * @param multipartFile 선임계리사 검증기초서류 파일
+     * @return UploadAuthFIleResultDto(isExistAllFile)
+     */
+    @PostMapping("/dev/auth-file/save/sractuary/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> uploadSrActuaryVerificationFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+            return ResponseEntity.ok(insuranceService.uploadSrActuaryVerificationFile(insId, multipartFile));
+        }
+
+    /**
+     * 금융감독원 인가허가파일 등록
+     * @param insId 보험 ID
+     * @param multipartFile 금융감독원 인가허가파일 파일
+     * @return UploadAuthFIleResultDto(isExistAllFile)
+     */
+    @PostMapping("/dev/auth-file/save/fssofficial/{insId}")
+    public ResponseEntity<UploadAuthFileResultDto> uploadFssOfficialDocFile(@PathVariable int insId, @RequestBody MultipartFile multipartFile) {
+        return ResponseEntity.ok(insuranceService.uploadFssOfficialDocFile(insId, multipartFile));
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/controller/dto/InsuranceForUploadAuthFileDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/controller/dto/InsuranceForUploadAuthFileDto.java
@@ -1,0 +1,39 @@
+package com.mju.insuranceCompany.service.insurance.controller.dto;
+
+import com.mju.insuranceCompany.service.insurance.domain.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+public class InsuranceForUploadAuthFileDto {
+    private int id;
+    private InsuranceType type;
+    private String name;
+    private String description;
+    private LocalDate developDate;
+    private SalesAuthorizationState salesAuthorizationState;
+    private Boolean isExistProd;
+    private Boolean isExistIso;
+    private Boolean isExistSrActuary;
+    private Boolean isExistFssOfficial;
+
+    public static InsuranceForUploadAuthFileDto toDto(Insurance insurance) {
+        DevelopInfo developInfo = insurance.getDevelopInfo();
+        SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
+        return new InsuranceForUploadAuthFileDto(
+                insurance.getId(),
+                insurance.getInsuranceType(),
+                insurance.getName(),
+                insurance.getDescription(),
+                developInfo.getDevelopDate(),
+                developInfo.getSalesAuthorizationState(),
+                salesAuthorizationFile.isExistProd(),
+                salesAuthorizationFile.isExistIso(),
+                salesAuthorizationFile.isExistSrActuary(),
+                salesAuthorizationFile.isExistFssOfficial()
+        );
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/controller/dto/UploadAuthFileResultDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/controller/dto/UploadAuthFileResultDto.java
@@ -1,0 +1,9 @@
+package com.mju.insuranceCompany.service.insurance.controller.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data @Builder
+public class UploadAuthFileResultDto {
+    private Boolean isExistAllFile;
+}

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Guarantee.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Guarantee.java
@@ -10,8 +10,7 @@ import javax.persistence.*;
  * @version 1.0
  * @created 09-5-2022 ���� 4:39:00
  */
-@Getter
-@Setter
+@Getter @Setter @ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Guarantee.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Guarantee.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
  * @version 1.0
  * @created 09-5-2022 ���� 4:39:00
  */
-@Getter @Setter @ToString
+@Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
@@ -273,19 +273,4 @@ public class Insurance {
 		return premium;
 	}
 
-	public void registerProdDeclaration(String fileUrl) {
-		this.getSalesAuthorizationFile().setProdDeclaration(fileUrl);
-	}
-
-	public void registerIsoVerification(String fileUrl) {
-		this.getSalesAuthorizationFile().setIsoVerification(fileUrl);
-	}
-
-	public void registerSrActuaryVerification(String fileUrl) {
-		this.getSalesAuthorizationFile().setSrActuaryVerification(fileUrl);
-	}
-
-	public void registerFssOfficialDoc(String fileUrl) {
-		this.getSalesAuthorizationFile().setFssOfficialDoc(fileUrl);
-	}
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
@@ -273,4 +273,41 @@ public class Insurance {
 		return premium;
 	}
 
+	public UploadAuthFileResultDto uploadSalesAuthFile(SalesAuthFileType fileType, String fileUrl) {
+		return switch (fileType) {
+			case PROD -> getUploadFileResultDto(salesAuthorizationFile.setProdDeclaration(fileUrl));
+			case ISO -> getUploadFileResultDto(salesAuthorizationFile.setIsoVerification(fileUrl));
+			case SR_ACTUARY -> getUploadFileResultDto(salesAuthorizationFile.setSrActuaryVerification(fileUrl));
+			case FSS_OFFICIAL -> getUploadFileResultDto(salesAuthorizationFile.setFssOfficialDoc(fileUrl));
+		};
+	}
+
+	public String getOriginSalesAuthorizationFileUrl(SalesAuthFileType fileType) {
+		return switch (fileType) {
+			case PROD -> this.salesAuthorizationFile.getProdDeclaration();
+			case ISO -> this.salesAuthorizationFile.getIsoVerification();
+			case SR_ACTUARY -> this.salesAuthorizationFile.getSrActuaryVerification();
+			case FSS_OFFICIAL -> this.salesAuthorizationFile.getFssOfficialDoc();
+		};
+	}
+
+	public String deleteSalesAuthFile(SalesAuthFileType fileType) {
+		this.developInfo.setSalesAuthorizationState(SalesAuthorizationState.DISALLOWANCE);
+		return switch (fileType) {
+			case PROD -> this.salesAuthorizationFile.deleteProdDeclaration();
+			case ISO -> this.salesAuthorizationFile.deleteIsoVerification();
+			case SR_ACTUARY -> this.salesAuthorizationFile.deleteSrActuaryVerification();
+			case FSS_OFFICIAL -> this.salesAuthorizationFile.deleteFssOfficialDoc();
+		};
+	}
+
+	public void updateSalesAuthorizationState(SalesAuthorizationState updatedState) {
+		this.developInfo.setSalesAuthorizationState(updatedState);
+	}
+
+	private UploadAuthFileResultDto getUploadFileResultDto(SalesAuthorizationFile salesAuthorizationFile) {
+		return UploadAuthFileResultDto.builder()
+				.isExistAllFile(salesAuthorizationFile.isExistAllFile()).build();
+	}
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/Insurance.java
@@ -6,10 +6,7 @@ import com.mju.insuranceCompany.global.utility.CriterionSetUtil;
 import com.mju.insuranceCompany.global.utility.TargetInfoCalculator;
 import com.mju.insuranceCompany.service.contract.domain.BuildingType;
 import com.mju.insuranceCompany.service.insurance.controller.dto.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -26,6 +23,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @Builder
+@ToString(exclude = {"developInfo", "salesAuthorizationFile"})
 public class Insurance {
 
 	@Id
@@ -47,6 +45,8 @@ public class Insurance {
 	@OneToOne(fetch = FetchType.LAZY, mappedBy = "insurance", cascade = CascadeType.ALL)
 	private SalesAuthorizationFile salesAuthorizationFile;
 
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////
 	private static Insurance createInsurance(InsuranceBasicInfoDto basicInfo,
 											 List<GuaranteeDto> guaranteeInfoList,
 										 	 int employeeId) {
@@ -126,58 +126,7 @@ public class Insurance {
 				.build();
 	}
 
-	public int inquireHealthPremium(String ssn, int riskCount){
-		int premium = 0;
-		int targetAge = CriterionSetUtil.setTargetAge((TargetInfoCalculator.targetAgeCalculator(ssn)));
-		boolean targetSex = TargetInfoCalculator.targetSexCalculator(ssn);
-		boolean riskCriterion = CriterionSetUtil.setRiskCriterion(riskCount);
-
-		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
-			HealthDetail healthDetail = (HealthDetail) insuranceDetail;
-			if (healthDetail.getTargetAge() == targetAge && healthDetail.isTargetSex() == targetSex && (healthDetail.isRiskCriterion()) == riskCriterion) {
-				premium = healthDetail.getPremium();
-				break;
-			}
-		}
-		if (premium == 0)
-			throw new NoResultantException();
-		return premium;
-	}
-
-	public int inquireFirePremium(BuildingType buildingType, Long collateralAmount){
-		int premium = 0;
-		Long collateralAmountCriterion = CriterionSetUtil.setCollateralAmountCriterion(collateralAmount);
-
-		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
-			FireDetail fireDetail = (FireDetail) insuranceDetail;
-			if (fireDetail.getTargetBuildingType() == buildingType && fireDetail.getCollateralAmountCriterion() == collateralAmountCriterion) {
-				premium = fireDetail.getPremium();
-				break;
-			}
-		}
-		if (premium == 0)
-			throw new NoResultantException();
-		return premium;
-	}
-
-	public int inquireCarPremium(String ssn, Long value){
-		int premium = 0;
-		int targetAge = CriterionSetUtil.setTargetAge(TargetInfoCalculator.targetAgeCalculator(ssn));
-		Long valueCriterion = CriterionSetUtil.setValueCriterion(value);
-
-		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
-			CarDetail carDetail = (CarDetail) insuranceDetail;
-			if (carDetail.getTargetAge() == targetAge && carDetail.getValueCriterion() == valueCriterion) {
-				premium = carDetail.getPremium();
-				break;
-			}
-		}
-		if (premium == 0)
-			throw new NoResultantException();
-		return premium;
-	}
-
-	private static void validatePremiumCondition(StandardPremiumDto standardPremiumDto){
+	private static void validatePremiumConditionForCalculate(StandardPremiumDto standardPremiumDto){
 		if(standardPremiumDto.getDamageAmount() <=0 ||
 				standardPremiumDto.getCountContract() <=0 ||
 				standardPremiumDto.getBusinessExpense() <=0 ||
@@ -187,7 +136,7 @@ public class Insurance {
 	}
 
 	private static int calcStandardPremium(StandardPremiumDto standardPremiumDto){
-		validatePremiumCondition(standardPremiumDto);
+		validatePremiumConditionForCalculate(standardPremiumDto);
 
 		long damageAmount = standardPremiumDto.getDamageAmount() * 10000;
 		long businessExpense = standardPremiumDto.getBusinessExpense() * 10000;
@@ -272,7 +221,71 @@ public class Insurance {
 		return (int) (stPremium * weightRatio);
 	}
 
+	//////////////////////////////////////////////////////////////////////////////////////////////////////
+	public int inquireHealthPremium(String ssn, int riskCount){
+		int premium = 0;
+		int targetAge = CriterionSetUtil.setTargetAge((TargetInfoCalculator.targetAgeCalculator(ssn)));
+		boolean targetSex = TargetInfoCalculator.targetSexCalculator(ssn);
+		boolean riskCriterion = CriterionSetUtil.setRiskCriterion(riskCount);
 
+		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
+			HealthDetail healthDetail = (HealthDetail) insuranceDetail;
+			if (healthDetail.getTargetAge() == targetAge && healthDetail.isTargetSex() == targetSex && (healthDetail.isRiskCriterion()) == riskCriterion) {
+				premium = healthDetail.getPremium();
+				break;
+			}
+		}
+		if (premium == 0)
+			throw new NoResultantException();
+		return premium;
+	}
 
+	public int inquireFirePremium(BuildingType buildingType, Long collateralAmount){
+		int premium = 0;
+		Long collateralAmountCriterion = CriterionSetUtil.setCollateralAmountCriterion(collateralAmount);
 
+		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
+			FireDetail fireDetail = (FireDetail) insuranceDetail;
+			if (fireDetail.getTargetBuildingType() == buildingType && fireDetail.getCollateralAmountCriterion() == collateralAmountCriterion) {
+				premium = fireDetail.getPremium();
+				break;
+			}
+		}
+		if (premium == 0)
+			throw new NoResultantException();
+		return premium;
+	}
+
+	public int inquireCarPremium(String ssn, Long value){
+		int premium = 0;
+		int targetAge = CriterionSetUtil.setTargetAge(TargetInfoCalculator.targetAgeCalculator(ssn));
+		Long valueCriterion = CriterionSetUtil.setValueCriterion(value);
+
+		for (InsuranceDetail insuranceDetail : this.insuranceDetailList) {
+			CarDetail carDetail = (CarDetail) insuranceDetail;
+			if (carDetail.getTargetAge() == targetAge && carDetail.getValueCriterion() == valueCriterion) {
+				premium = carDetail.getPremium();
+				break;
+			}
+		}
+		if (premium == 0)
+			throw new NoResultantException();
+		return premium;
+	}
+
+	public void registerProdDeclaration(String fileUrl) {
+		this.getSalesAuthorizationFile().setProdDeclaration(fileUrl);
+	}
+
+	public void registerIsoVerification(String fileUrl) {
+		this.getSalesAuthorizationFile().setIsoVerification(fileUrl);
+	}
+
+	public void registerSrActuaryVerification(String fileUrl) {
+		this.getSalesAuthorizationFile().setSrActuaryVerification(fileUrl);
+	}
+
+	public void registerFssOfficialDoc(String fileUrl) {
+		this.getSalesAuthorizationFile().setFssOfficialDoc(fileUrl);
+	}
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthFileType.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthFileType.java
@@ -1,0 +1,24 @@
+package com.mju.insuranceCompany.service.insurance.domain;
+
+import com.mju.insuranceCompany.service.insurance.exception.SalesAuthFileTypeBadRequestException;
+
+public enum SalesAuthFileType {
+    PROD("prod"),
+    ISO("iso"),
+    SR_ACTUARY("sracutuary"),
+    FSS_OFFICIAL("fssofficial");
+
+    private String typeName;
+    SalesAuthFileType(String typeName) {
+        this.typeName = typeName;
+    }
+
+    public static SalesAuthFileType ofType(String source) {
+        for(SalesAuthFileType type : SalesAuthFileType.values()) {
+            if(type.typeName.equals(source)) {
+                return type;
+            }
+        }
+        throw new SalesAuthFileTypeBadRequestException();
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
@@ -18,10 +18,6 @@ import java.time.LocalDateTime;
 @Entity
 public class SalesAuthorizationFile {
 
-	public enum SalesAuthFileType {
-		PROD, ISO, SR_ACTUARY, FSS_OFFICIAL
-	}
-
 	@Id
 	private int insuranceId;
 	@MapsId

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
@@ -18,6 +18,10 @@ import java.time.LocalDateTime;
 @Entity
 public class SalesAuthorizationFile {
 
+	public enum SalesAuthFileType {
+		PROD, ISO, SR_ACTUARY, FSS_OFFICIAL
+	}
+
 	@Id
 	private int insuranceId;
 	@MapsId
@@ -34,6 +38,11 @@ public class SalesAuthorizationFile {
 		this.prodDeclaration = url;
 		this.modifiedProd = LocalDateTime.now();
 		return this;
+	}
+	public String deleteProdDeclaration() {
+		String returnUrl = prodDeclaration;
+		this.prodDeclaration = null;
+		return returnUrl;
 	}
 	public boolean isExistProd() {
 		if (prodDeclaration != null) {
@@ -52,6 +61,11 @@ public class SalesAuthorizationFile {
 		this.modifiedIso = LocalDateTime.now();
 		return this;
 	}
+	public String deleteIsoVerification() {
+		String returnUrl = isoVerification;
+		this.isoVerification = null;
+		return returnUrl;
+	}
 	public boolean isExistIso() {
 		if (isoVerification != null) {
 			return !isoVerification.isBlank();
@@ -69,6 +83,11 @@ public class SalesAuthorizationFile {
 		this.modifiedSrActuary = LocalDateTime.now();
 		return this;
 	}
+	public String deleteSrActuaryVerification() {
+		String returnUrl = srActuaryVerification;
+		this.srActuaryVerification = null;
+		return returnUrl;
+	}
 	public boolean isExistSrActuary() {
 		if (srActuaryVerification != null) {
 			return !srActuaryVerification.isBlank();
@@ -85,6 +104,11 @@ public class SalesAuthorizationFile {
 		this.fssOfficialDoc = url;
 		this.modifiedFss = LocalDateTime.now();
 		return this;
+	}
+	public String deleteFssOfficialDoc() {
+		String returnUrl = fssOfficialDoc;
+		this.fssOfficialDoc = null;
+		return returnUrl;
 	}
 	public boolean isExistFssOfficial() {
 		if (fssOfficialDoc != null) {

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/domain/SalesAuthorizationFile.java
@@ -30,36 +30,75 @@ public class SalesAuthorizationFile {
 	 */
 	private String prodDeclaration;
 	private LocalDateTime modifiedProd;
+	public SalesAuthorizationFile setProdDeclaration(String url) {
+		this.prodDeclaration = url;
+		this.modifiedProd = LocalDateTime.now();
+		return this;
+	}
+	public boolean isExistProd() {
+		if (prodDeclaration != null) {
+			return !prodDeclaration.isBlank();
+		}
+		return false;
+	}
 
 	/**
 	 * 보험요율산출기관 검증확인서
 	 */
 	private String isoVerification;
 	private LocalDateTime modifiedIso;
+	public SalesAuthorizationFile setIsoVerification(String url) {
+		this.isoVerification = url;
+		this.modifiedIso = LocalDateTime.now();
+		return this;
+	}
+	public boolean isExistIso() {
+		if (isoVerification != null) {
+			return !isoVerification.isBlank();
+		}
+		return false;
+	}
 
 	/**
 	 * 선임계리사 검증기초서류
 	 */
 	private String srActuaryVerification;
 	private LocalDateTime modifiedSrActuary;
+	public SalesAuthorizationFile setSrActuaryVerification(String url) {
+		this.srActuaryVerification = url;
+		this.modifiedSrActuary = LocalDateTime.now();
+		return this;
+	}
+	public boolean isExistSrActuary() {
+		if (srActuaryVerification != null) {
+			return !srActuaryVerification.isBlank();
+		}
+		return false;
+	}
 
 	/**
 	 * 금융감독원 인가허가파일
 	 */
 	private String fssOfficialDoc;
 	private LocalDateTime modifiedFss;
+	public SalesAuthorizationFile setFssOfficialDoc(String url) {
+		this.fssOfficialDoc = url;
+		this.modifiedFss = LocalDateTime.now();
+		return this;
+	}
+	public boolean isExistFssOfficial() {
+		if (fssOfficialDoc != null) {
+			return !fssOfficialDoc.isBlank();
+		}
+		return false;
+	}
 
 	/**
 	 * 모든 파일이 존재하는지 확인하는 메소드
 	 * @return 모든 파일이 있으면 true, 하나의 파일이라도 없으면 false
 	 */
 	public boolean isExistAllFile() {
-		return (this.getProdDeclaration()!=null) && (this.getFssOfficialDoc()!=null)
-				&& (this.getIsoVerification()!=null) && (this.getSrActuaryVerification()!=null);
-	}
-
-	public void modifyProdDeclaration() {
-
+		return isExistProd() && isExistIso() && isExistSrActuary() && isExistFssOfficial();
 	}
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/exception/InsuranceErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/exception/InsuranceErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum InsuranceErrorCode implements ErrorCode {
 
     INSURANCE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "입력하신 ID에 해당하는 보험 정보가 존재하지 않습니다."),
+    SALES_AUTH_FILE_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 타입으로 요청하였습니다.")
 
     ;
 

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/exception/SalesAuthFileTypeBadRequestException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/exception/SalesAuthFileTypeBadRequestException.java
@@ -1,0 +1,9 @@
+package com.mju.insuranceCompany.service.insurance.exception;
+
+import com.mju.insuranceCompany.global.exception.MyException;
+
+public class SalesAuthFileTypeBadRequestException extends MyException {
+    public SalesAuthFileTypeBadRequestException() {
+        super(InsuranceErrorCode.SALES_AUTH_FILE_TYPE_BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
@@ -1,16 +1,19 @@
 package com.mju.insuranceCompany.service.insurance.service;
 
 import com.mju.insuranceCompany.global.utility.AuthenticationExtractor;
+import com.mju.insuranceCompany.global.utility.S3Client;
 import com.mju.insuranceCompany.service.employee.domain.Employee;
 import com.mju.insuranceCompany.service.employee.exception.EmployeeIdNotFoundException;
 import com.mju.insuranceCompany.service.employee.repository.EmployeeRepository;
 import com.mju.insuranceCompany.service.insurance.controller.dto.*;
 import com.mju.insuranceCompany.service.insurance.domain.Insurance;
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationFile;
 import com.mju.insuranceCompany.service.insurance.exception.InsuranceIdNotFoundException;
 import com.mju.insuranceCompany.service.insurance.repository.InsuranceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -114,4 +117,49 @@ public class InsuranceService {
         );
         insuranceRepository.save(fireInsurance);
     }
+
+    public InsuranceForUploadAuthFileDto getInsuranceInfoForUploadAuthFile(int insuranceId) {
+        Insurance insurance = insuranceRepository.findById(insuranceId).orElseThrow(InsuranceIdNotFoundException::new);
+        return InsuranceForUploadAuthFileDto.toDto(insurance);
+    }
+
+    private final S3Client s3Client;
+
+    public UploadAuthFileResultDto uploadProdDeclarationFile(int insuranceId, MultipartFile multipartFile) {
+        Insurance insurance = insuranceRepository.findById(insuranceId).orElseThrow(InsuranceIdNotFoundException::new);
+        String fileUrl = s3Client.uploadFile(multipartFile);
+        SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
+        salesAuthorizationFile.setProdDeclaration(fileUrl);
+        return getUploadFileResultDto(salesAuthorizationFile);
+    }
+
+    public UploadAuthFileResultDto uploadIsoVerificationFile(int insuranceId, MultipartFile multipartFile) {
+        Insurance insurance = insuranceRepository.findById(insuranceId).orElseThrow(InsuranceIdNotFoundException::new);
+        String fileUrl = s3Client.uploadFile(multipartFile);
+        SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
+        salesAuthorizationFile.setIsoVerification(fileUrl);
+        return getUploadFileResultDto(salesAuthorizationFile);
+    }
+
+    public UploadAuthFileResultDto uploadSrActuaryVerificationFile(int insuranceId, MultipartFile multipartFile) {
+        Insurance insurance = insuranceRepository.findById(insuranceId).orElseThrow(InsuranceIdNotFoundException::new);
+        String fileUrl = s3Client.uploadFile(multipartFile);
+        SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
+        salesAuthorizationFile.setSrActuaryVerification(fileUrl);
+        return getUploadFileResultDto(salesAuthorizationFile);
+    }
+
+    public UploadAuthFileResultDto uploadFssOfficialDocFile(int insuranceId, MultipartFile multipartFile) {
+        Insurance insurance = insuranceRepository.findById(insuranceId).orElseThrow(InsuranceIdNotFoundException::new);
+        String fileUrl = s3Client.uploadFile(multipartFile);
+        SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
+        salesAuthorizationFile.setFssOfficialDoc(fileUrl);
+        return getUploadFileResultDto(salesAuthorizationFile);
+    }
+
+    private UploadAuthFileResultDto getUploadFileResultDto(SalesAuthorizationFile salesAuthorizationFile) {
+        return UploadAuthFileResultDto.builder()
+                .isExistAllFile(salesAuthorizationFile.isExistAllFile()).build();
+    }
+
 }

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
@@ -7,6 +7,7 @@ import com.mju.insuranceCompany.service.employee.exception.EmployeeIdNotFoundExc
 import com.mju.insuranceCompany.service.employee.repository.EmployeeRepository;
 import com.mju.insuranceCompany.service.insurance.controller.dto.*;
 import com.mju.insuranceCompany.service.insurance.domain.Insurance;
+import com.mju.insuranceCompany.service.insurance.domain.SalesAuthFileType;
 import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationFile;
 import com.mju.insuranceCompany.service.insurance.domain.SalesAuthorizationState;
 import com.mju.insuranceCompany.service.insurance.exception.InsuranceIdNotFoundException;
@@ -129,21 +130,21 @@ public class InsuranceService {
         return InsuranceForUploadAuthFileDto.toDto(insurance);
     }
 
-    public UploadAuthFileResultDto uploadAuthFile(int insuranceId, MultipartFile multipartFile, SalesAuthorizationFile.SalesAuthFileType fileType) {
+    public UploadAuthFileResultDto uploadAuthFile(int insuranceId, MultipartFile multipartFile, SalesAuthFileType fileType) {
         Insurance insurance = getInsuranceById(insuranceId);
         String fileUrl = s3Client.uploadFile(multipartFile);
         SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
         return getUploadFileResultDto(fileType, salesAuthorizationFile, fileUrl);
     }
 
-    public UploadAuthFileResultDto updateAuthFile(int insuranceId, MultipartFile multipartFile, SalesAuthorizationFile.SalesAuthFileType fileType) {
+    public UploadAuthFileResultDto updateAuthFile(int insuranceId, MultipartFile multipartFile, SalesAuthFileType fileType) {
         Insurance insurance = getInsuranceById(insuranceId);
         SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
         String fileUrl = s3Client.updateFile(multipartFile, salesAuthorizationFile.getProdDeclaration());
         return getUploadFileResultDto(fileType, salesAuthorizationFile, fileUrl);
     }
 
-    public void deleteAuthFile(int insuranceId, SalesAuthorizationFile.SalesAuthFileType fileType) {
+    public void deleteAuthFile(int insuranceId, SalesAuthFileType fileType) {
         Insurance insurance = getInsuranceById(insuranceId);
         SalesAuthorizationFile salesAuthorizationFile = insurance.getSalesAuthorizationFile();
         switch (fileType) {
@@ -165,7 +166,7 @@ public class InsuranceService {
         insurance.getDevelopInfo().setSalesAuthorizationState(salesAuthorizationState);
     }
 
-    private UploadAuthFileResultDto getUploadFileResultDto(SalesAuthorizationFile.SalesAuthFileType fileType, SalesAuthorizationFile salesAuthorizationFile, String fileUrl) {
+    private UploadAuthFileResultDto getUploadFileResultDto(SalesAuthFileType fileType, SalesAuthorizationFile salesAuthorizationFile, String fileUrl) {
         return switch (fileType) {
             case PROD -> getUploadFileResultDto(salesAuthorizationFile.setProdDeclaration(fileUrl));
             case ISO -> getUploadFileResultDto(salesAuthorizationFile.setIsoVerification(fileUrl));

--- a/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/insurance/service/InsuranceService.java
@@ -39,13 +39,13 @@ public class InsuranceService {
         return insuranceRepository.findAll().stream().map(InsuranceListDto::toDto).toList();
     }
     
-    public InsuranceGuaranteeDto getInsuranceGuaranteeById(int id) {
-        Insurance insurance = getInsuranceById(id);
+    public InsuranceGuaranteeDto getInsuranceGuaranteeById(int insuranceId) {
+        Insurance insurance = getInsuranceById(insuranceId);
         return InsuranceGuaranteeDto.toDto(insurance);
     }
 
-    public InsurancePremiumDto inquireHealthPremium(int id, InquireHealthPremiumDto requestDto) {
-        Insurance insurance = getInsuranceById(id);
+    public InsurancePremiumDto inquireHealthPremium(int insuranceId, InquireHealthPremiumDto requestDto) {
+        Insurance insurance = getInsuranceById(insuranceId);
         int premium = insurance.inquireHealthPremium(requestDto.getSsn(), requestDto.getRiskCount());
         return InsurancePremiumDto.builder().premium(premium).build();
     }

--- a/src/main/java/com/mju/insuranceCompany/service/user/controller/UserController.java
+++ b/src/main/java/com/mju/insuranceCompany/service/user/controller/UserController.java
@@ -15,10 +15,8 @@ public class UserController {
 
     @PostMapping("/sign-up/{cId}")
     public ResponseEntity signUp(@PathVariable int cId, @RequestBody UserBasicRequest request) {
-        if(userService.signUp(cId, request))
-            return ResponseEntity.noContent().build();
-        else
-            return ResponseEntity.internalServerError().build();
+        userService.signUp(cId, request);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/mju/insuranceCompany/service/user/exception/DuplicateUserIdException.java
+++ b/src/main/java/com/mju/insuranceCompany/service/user/exception/DuplicateUserIdException.java
@@ -1,0 +1,9 @@
+package com.mju.insuranceCompany.service.user.exception;
+
+import com.mju.insuranceCompany.global.exception.MyException;
+
+public class DuplicateUserIdException extends MyException {
+    public DuplicateUserIdException() {
+        super(UserErrorCode.DUPLICATE_USER_ID);
+    }
+}

--- a/src/main/java/com/mju/insuranceCompany/service/user/exception/UserErrorCode.java
+++ b/src/main/java/com/mju/insuranceCompany/service/user/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다."),
-    USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 ID입니다.")
+    USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 ID입니다."),
+    DUPLICATE_USER_ID(HttpStatus.BAD_REQUEST, "해당 ID는 이미 존재하는 ID입니다.")
     ;
 
 

--- a/src/main/java/com/mju/insuranceCompany/service/user/service/UserService.java
+++ b/src/main/java/com/mju/insuranceCompany/service/user/service/UserService.java
@@ -1,9 +1,10 @@
 package com.mju.insuranceCompany.service.user.service;
 
-import com.mju.insuranceCompany.service.user.exception.UserIdNotFoundException;
 import com.mju.insuranceCompany.service.user.controller.dto.UserBasicRequest;
 import com.mju.insuranceCompany.service.user.domain.UserType;
 import com.mju.insuranceCompany.service.user.domain.Users;
+import com.mju.insuranceCompany.service.user.exception.DuplicateUserIdException;
+import com.mju.insuranceCompany.service.user.exception.UserIdNotFoundException;
 import com.mju.insuranceCompany.service.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,9 @@ public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final PasswordEncoder encoder;
 
-    public boolean signUp(int cId, UserBasicRequest request) {
+    public void signUp(int cId, UserBasicRequest request) {
+        checkDuplicateUserId(request.getUserId());
+
         String encodePassword = encoder.encode(request.getPassword());
         Users user = Users.builder()
                 .userId(request.getUserId())
@@ -30,11 +33,12 @@ public class UserService implements UserDetailsService {
                 .roleId(cId)
                 .type(UserType.ROLE_CUSTOMER)
                 .build();
-        user = userRepository.save(user);
-        return user.getId() > 0;
+        userRepository.save(user);
     }
 
     public void signUpEmployee(int eId, UserBasicRequest request, UserType type) {
+        checkDuplicateUserId(request.getUserId());
+
         String encodePassword = encoder.encode(request.getPassword());
         Users user = Users.builder()
                 .userId(request.getUserId())
@@ -45,12 +49,19 @@ public class UserService implements UserDetailsService {
         userRepository.save(user);
     }
 
+    /**
+     * User ID 중복체크 메소드.
+     * 만일 존재하는 ID라면, DuplicateUserIdException을 발생.
+     * @param userId 회원가입을 요청한 user id
+     */
+    private void checkDuplicateUserId(String userId) {
+        if(userRepository.findByUserId(userId).isPresent()) {
+            throw new DuplicateUserIdException();
+        }
+    }
+
     @Override
     public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         return userRepository.findByUserId(id).orElseThrow(UserIdNotFoundException::new);
-//        Users user = userRepository.findByUserId(id).orElseThrow();
-//        return new org.springframework.security.core.userdetails.
-//                User(user.getUserId(), user.getPassword(),
-//                List.of(new SimpleGrantedAuthority(user.getType().name())));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# connection time out - 7sec.
+spring.datasource.hikari.connection-timeout=7000

--- a/src/main/resources/security-ex.properties
+++ b/src/main/resources/security-ex.properties
@@ -1,0 +1,7 @@
+jwt.secretkey= secret_example
+
+cloud.aws.stack.auto= false
+cloud.aws.s3.bucket=
+cloud.aws.region.static= 
+cloud.aws.credentials.access-key=
+cloud.aws.credentials.secret-key=

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -1,8 +1,0 @@
-jwt.secretkey= secret_example
-
-cloud.aws.s3.bucket= mju-insurance-company
-cloud.aws.region.static= ap-northeast-2
-cloud.aws.stack.auto= false
-
-cloud.aws.credentials.access-key= AKIA6RHA2E6RUI4MBIJB
-cloud.aws.credentials.secret-key= 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

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -1,1 +1,8 @@
 jwt.secretkey= secret_example
+
+cloud.aws.s3.bucket= mju-insurance-company
+cloud.aws.region.static= ap-northeast-2
+cloud.aws.stack.auto= false
+
+cloud.aws.credentials.access-key= AKIA6RHA2E6RUI4MBIJB
+cloud.aws.credentials.secret-key= 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


### PR DESCRIPTION
## Pull Request
> 이번 PR은 판매인가파일 등록, 수정, 삭제 및 판매인가상태 변경에 대한 api 구현과 회원가입 시 발생할 수 있는 유저 아이디 중복체크에 대한 예외를 처리한 PR입니다.

## 판매인가파일 등록, 수정, 삭제 및 판매인가상태 변경 api
- 엔드포인트는 EmployeeController에 구현되어 있다.
- InsuranceService로부터 로직을 수행한다.
- MulitpartFile로 요청된 파일을 AWS S3에 업로드한 후, S3 객체의 url을 데이터베이스의 sales_authorization_file 테이블의 각 문서 필드에 저장하도로 한다.
- 클라이언트로의 리턴값은 isExistAllFile이라는 Boolean 변수를 통해 모든 파일이 존재하는지에 대한 여부를 리턴한다.
- 클라이언트는 리턴값이 true일 경우, 판매인가상태 변경을 유도하도록 한다.
- ***중요!!!!*** 업로드되어 리턴된 S3 객체 url이 현재 DB 테이블의 필드 길이보다 긴 문제가 발생하여, 로컬에서 실행 시sales_authorization_file의 각 문서 필드들을 VARCHAR(255)로 변경해야 한다! 이와 관련하여 추후 AWS RDS에 적용하고자 한다.

## 유저 아이디 중복체크 예외 처리
- UserService에서 회원가입 처리 시, 입력된 user id를 중복체크한다. 만일 중복 발생 시, 새로 예외 클래스를 정의한DuplicateUserIdException 클래스를 발생시키도록 하여 클라이언트에게 에러 메시지가 리턴되도록 하였다. 
```
private void checkDuplicateUserId(String userId) {
        if(userRepository.findByUserId(userId).isPresent()) {
            throw new DuplicateUserIdException();
        }
    }
```
