### PR TITLE
AccidentDocumentFile 반환 시 손해 사정서 추가 & 파일 업로드 시 파일 존재하면 삭제하도록 변경

### DIFF
--- a/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompCarAccidentDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompCarAccidentDto.java
@@ -58,6 +58,7 @@ public class CompCarAccidentDto {
                     case CAR_ACCIDENT_FACT_CONFIRMATION -> fileMap.put(AccDocType.CAR_ACCIDENT_FACT_CONFIRMATION.getName(), file.getFileAddress());
                     case PAYMENT_RESOLUTION -> fileMap.put(AccDocType.PAYMENT_RESOLUTION.getName(), file.getFileAddress());
                     case INVESTIGATE_ACCIDENT -> fileMap.put(AccDocType.INVESTIGATE_ACCIDENT.getName(), file.getFileAddress());
+                    case LOSS_ASSESSMENT -> fileMap.put(AccDocType.LOSS_ASSESSMENT.getName(), file.getFileAddress());
                 }
             }
         }

--- a/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompFireAccidentDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompFireAccidentDto.java
@@ -48,6 +48,7 @@ public class CompFireAccidentDto {
                     case REPAIR_ESTIMATE -> fileMap.put(AccDocType.REPAIR_ESTIMATE.getName(), file.getFileAddress());
                     case REPAIR_RECEIPT -> fileMap.put(AccDocType.REPAIR_RECEIPT.getName(), file.getFileAddress());
                     case INVESTIGATE_ACCIDENT -> fileMap.put(AccDocType.INVESTIGATE_ACCIDENT.getName(), file.getFileAddress());
+                    case LOSS_ASSESSMENT -> fileMap.put(AccDocType.LOSS_ASSESSMENT.getName(), file.getFileAddress());
                 }
             }
         }

--- a/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompInjuryAccidentDto.java
+++ b/src/main/java/com/mju/insuranceCompany/service/accident/controller/dto/CompInjuryAccidentDto.java
@@ -47,6 +47,7 @@ public class CompInjuryAccidentDto {
                     case MEDICAL_CERTIFICATION -> fileMap.put(AccDocType.MEDICAL_CERTIFICATION.getName(), file.getFileAddress());
                     case CONFIRM_ADMISSION_DISCHARGE -> fileMap.put(AccDocType.CONFIRM_ADMISSION_DISCHARGE.getName(), file.getFileAddress());
                     case INVESTIGATE_ACCIDENT -> fileMap.put(AccDocType.INVESTIGATE_ACCIDENT.getName(), file.getFileAddress());
+                    case LOSS_ASSESSMENT -> fileMap.put(AccDocType.LOSS_ASSESSMENT.getName(), file.getFileAddress());
                 }
             }
         }

--- a/src/main/java/com/mju/insuranceCompany/service/accident/domain/Accident.java
+++ b/src/main/java/com/mju/insuranceCompany/service/accident/domain/Accident.java
@@ -44,7 +44,7 @@ public abstract class Accident {
 	protected long lossReserves; // 지급준비금
 	protected LocalDateTime dateOfAccident;
 	protected LocalDateTime dateOfReport;
-	@OneToMany(mappedBy = "accidentId", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "accidentId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	protected List<AccidentDocumentFile> accidentDocumentFileList;
 
 	public abstract boolean isRequestOnSite();
@@ -81,6 +81,8 @@ public abstract class Accident {
 		if(this.accidentDocumentFileList == null) {
 			this.setAccidentDocumentFileList(new ArrayList<>());
 		}
+		// 이미 존재한다면 삭제
+		accidentDocumentFileList.remove(AccidentDocumentFile.createDummyForEquals(docType));
 		this.accidentDocumentFileList.add(AccidentDocumentFile.createAccidentDocumentFile(docType, fileUrl, this.id));
 	}
 

--- a/src/main/java/com/mju/insuranceCompany/service/accident/domain/accidentDocumentFile/AccidentDocumentFile.java
+++ b/src/main/java/com/mju/insuranceCompany/service/accident/domain/accidentDocumentFile/AccidentDocumentFile.java
@@ -42,16 +42,21 @@ public class AccidentDocumentFile {
 				.build();
 	}
 
+	public static AccidentDocumentFile createDummyForEquals(AccDocType accDocType) {
+		return AccidentDocumentFile.builder()
+				.type(accDocType).build();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		AccidentDocumentFile that = (AccidentDocumentFile) o;
-		return Objects.equals(getFileAddress(), that.getFileAddress()) && getType() == that.getType();
+		return type == that.type;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(getFileAddress(), getType());
+		return Objects.hash(type);
 	}
 }

--- a/src/test/java/com/mju/insuranceCompany/FindTest.java
+++ b/src/test/java/com/mju/insuranceCompany/FindTest.java
@@ -1,0 +1,59 @@
+package com.mju.insuranceCompany;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+class FindTest {
+
+
+    @Test
+    void findTest () throws Exception{
+        //given
+        Tester k24 = new Tester("Kim", 24);
+        Tester k25 = new Tester("Kim", 25);
+        Tester l40 = new Tester("Lee", 40);
+        Tester l41 = new Tester("Lee", 41);
+
+        ArrayList<Tester> tt = new ArrayList<>();
+        tt.add(k24);
+        tt.add(l40);
+        //when
+
+        int i = tt.indexOf(k25);
+        int l = tt.indexOf(l41);
+        boolean cl = tt.contains(l41);
+        //then
+        Assertions.assertThat(i).isSameAs(0);
+        Assertions.assertThat(l).isSameAs(1);
+        Assertions.assertThat(cl).isSameAs(true);
+
+
+    }
+
+
+    static class Tester{
+        private String name;
+        private int age;
+
+        public Tester(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Tester tester = (Tester) o;
+            return Objects.equals(name, tester.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+    }
+}


### PR DESCRIPTION
### 손해 사정서 함께 반환하도록 수정

손해 사정서만 올리고 작업을 중단할 경우, 손해사정서의 유무를 통해 다음 작업을 진행하도록 설정.

### 파일 업데이트 생성

파일이 이미 존재한다면 삭제하고 추가해주도록 설정
사유 : 같은 id에 중복되는 파일이 존재해서, 이럴 경우엔 어떤 것을 불러오는지 알 수가 없음.
![image](https://user-images.githubusercontent.com/76154390/206071511-82080780-d3ce-48bd-aa2f-eb9805d85971.png)
